### PR TITLE
relax build dependencies to allow base-4.8 (GHC-7.10) and transformers-0.4

### DIFF
--- a/SmtLib.cabal
+++ b/SmtLib.cabal
@@ -57,9 +57,9 @@ library
   -- other-modules:
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >= 4.6 && < 4.8
+  build-depends:       base >= 4.6 && < 4.9
                        , parsec ==3.1.*
-                       , transformers ==0.3.*
+                       , transformers >=0.3 && <0.5
 
   default-language: Haskell2010
   -- Directories containing source files.


### PR DESCRIPTION
This relax build dependencies to allow base-4.8 (GHC-7.10) and transformers-0.4.
