### PR TITLE
GenResponse instance of ShowSL should print Success as "success" instead of "Success"

### DIFF
--- a/Smtlib/Syntax/ShowSL.hs
+++ b/Smtlib/Syntax/ShowSL.hs
@@ -173,7 +173,7 @@ instance ShowSL CmdResponse where
 
 instance ShowSL GenResponse where
   showSL Unsupported = "unsupported"
-  showSL Success = "Success"
+  showSL Success = "success"
   showSL (Error s) = "(error " ++ s ++ ")"
 
 instance ShowSL ErrorBehavior where


### PR DESCRIPTION
Currently GenResponse instance of ShowSL print Success value as "Success", but it should print "success" according to SMT-LIB2.
