### PR TITLE
SMT-LIB2 comment

### DIFF
--- a/Smtlib/Parsers/CommandsParsers.hs
+++ b/Smtlib/Parsers/CommandsParsers.hs
@@ -32,7 +32,7 @@ import           Text.ParserCombinators.Parsec as Pc
 
 
 parseSource :: ParsecT String u Identity Source
-parseSource = Pc.many $ parseCommand <* Pc.try emptySpace
+parseSource = emptySpace *> (Pc.many $ parseCommand <* Pc.try emptySpace)
 
 
 {-

--- a/Smtlib/Parsers/CommonParsers.hs
+++ b/Smtlib/Parsers/CommonParsers.hs
@@ -115,8 +115,15 @@ false = string "false"
 
 
 emptySpace :: ParsecT String u Identity String
-emptySpace = Pc.try $ Pc.many $
-    char ' ' <|> char '\n' <|> char '\t' <|> char '\r'
+emptySpace = liftM concat $ Pc.try $ Pc.many $
+    liftM (\c -> [c]) (char ' ' <|> char '\n' <|> char '\t' <|> char '\r') <|> comment
+
+comment :: ParsecT String u Identity String
+comment = char ';' <:> scan
+  where
+    scan  = do{ c <- char '\n' <|> char '\r'; return [c] }
+          <|>
+            do{ c <- anyChar; cs <- scan; return (c:cs) }
 
 reservedWords :: ParsecT String u Identity String
 reservedWords =  string "let"


### PR DESCRIPTION
This patch makes the parser to accept comment syntax in SMT-LIB2.
