### PR TITLE
fix typo: produce-assignnments -> produce-assignments

### DIFF
--- a/Smtlib/Parsers/CommandsParsers.hs
+++ b/Smtlib/Parsers/CommandsParsers.hs
@@ -383,7 +383,7 @@ parseProduceModels = do
 
 parseProduceAssignments :: ParsecT String u Identity Option
 parseProduceAssignments = do
-  _ <- string ":produce-assignnments"
+  _ <- string ":produce-assignments"
   _ <- spaces
   val <- parseBool
   return $  ProduceAssignments val


### PR DESCRIPTION
This fixes typo in Smtlib/Parsers/CommandsParsers.hs.
- produce-assignnments -> produce-assignments
