### PR TITLE
TValuationPair instance of ShowSL should print boolean value using showSL

### DIFF
--- a/Smtlib/Syntax/ShowSL.hs
+++ b/Smtlib/Syntax/ShowSL.hs
@@ -202,4 +202,4 @@ instance ShowSL ValuationPair where
     "(" ++ showSL term1 ++ " " ++ showSL term2 ++ ")"
 
 instance ShowSL TValuationPair where
-  showSL (TValuationPair str b) = "(" ++ str ++ " " ++ show b ++ ")"
+  showSL (TValuationPair str b) = "(" ++ str ++ " " ++ showSL b ++ ")"


### PR DESCRIPTION
Currently TValuationPair instance of ShowSL uses show to print boolean value, but it should use showSL instead.
