### PR TITLE
fix problems in parseInfoFlags parser

### DIFF
--- a/Smtlib/Parsers/CommandsParsers.hs
+++ b/Smtlib/Parsers/CommandsParsers.hs
@@ -437,14 +437,14 @@ parseOptionAttribute = do
 -}
 
 parseInfoFlags :: ParsecT String u Identity InfoFlags
-parseInfoFlags = parseErrorBehaviour
-             <|> parseName
-             <|> parseAuthors
-             <|> parseVersion
-             <|> parseStatus
-             <|> parseReasonUnknown
+parseInfoFlags = Pc.try parseErrorBehaviour
+             <|> Pc.try parseName
+             <|> Pc.try parseAuthors
+             <|> Pc.try parseVersion
+             <|> Pc.try parseStatus
+             <|> Pc.try parseReasonUnknown
+             <|> Pc.try parseAllStatistics
              <|> parseInfoKeyword
-             <|> parseAllStatistics
 
 
 parseErrorBehaviour :: ParsecT String u Identity InfoFlags


### PR DESCRIPTION
- We need to use 'try' combinator, because each parser shares a common prefix ':'.
- The most general 'parseInfoKeyword' parser should be the last parser.
