### PR TITLE
Support commands and options of SMT-LIB 2.5 

### DIFF
--- a/Smtlib/Parsers/CommandsParsers.hs
+++ b/Smtlib/Parsers/CommandsParsers.hs
@@ -437,14 +437,14 @@ parseOptionAttribute = do
 -}
 
 parseInfoFlags :: ParsecT String u Identity InfoFlags
-parseInfoFlags = parseErrorBehaviour
-             <|> parseName
-             <|> parseAuthors
-             <|> parseVersion
-             <|> parseStatus
-             <|> parseReasonUnknown
+parseInfoFlags = Pc.try parseErrorBehaviour
+             <|> Pc.try parseName
+             <|> Pc.try parseAuthors
+             <|> Pc.try parseVersion
+             <|> Pc.try parseStatus
+             <|> Pc.try parseReasonUnknown
+             <|> Pc.try parseAllStatistics
              <|> parseInfoKeyword
-             <|> parseAllStatistics
 
 
 parseErrorBehaviour :: ParsecT String u Identity InfoFlags

--- a/Smtlib/Parsers/ResponseParsers.hs
+++ b/Smtlib/Parsers/ResponseParsers.hs
@@ -17,6 +17,7 @@ import           Control.Applicative           as Ctr hiding ((<|>))
 import           Control.Monad
 import           Data.Functor.Identity
 import           Smtlib.Parsers.CommonParsers
+import           Smtlib.Parsers.CommandsParsers
 import           Smtlib.Syntax.Syntax        as CmdRsp
 import           Text.Parsec.Prim              as Prim
 import           Text.ParserCombinators.Parsec as Pc
@@ -32,7 +33,9 @@ parseCmdResult = Pc.try parseCmdGenResponse
              <|> Pc.try parseCmdGetProof
              <|> Pc.try parseCmdGetProof
              <|> Pc.try parseCmdGetValueResponse
-             <|> parseCmdGetOptionResponse
+             <|> Pc.try parseCmdGetModelResponse
+             <|> Pc.try parseCmdGetOptionResponse
+             <|> Pc.try parseCmdEchoResponse
 
 {-
    #########################################################################
@@ -304,7 +307,24 @@ parseTValuationPair = do
     return $ TValuationPair symb bval
 
 
+{-
+   #########################################################################
+   #                                                                       #
+   #                       Parser Cmd Get model response                   #
+   #                                                                       #
+   #########################################################################
+-}
 
+
+parseCmdGetModelResponse :: ParsecT String u Identity CmdResponse
+parseCmdGetModelResponse = liftM CmdGetModelResponse parseGetModelResponse
+
+
+
+-- parse Get Model response
+parseGetModelResponse :: ParsecT String u Identity [Command]
+parseGetModelResponse =
+    aspO *> (Pc.many $ parseCommand <* Pc.try emptySpace) <* aspC
 
 
 {-
@@ -323,6 +343,23 @@ parseCmdGetOptionResponse = liftM CmdGetOptionResponse parseGetOptionResponse
 -- parse Get Option Response
 parseGetOptionResponse :: ParsecT String u Identity AttrValue
 parseGetOptionResponse = parseAttributeValue
+
+{-
+   #########################################################################
+   #                                                                       #
+   #                       Parser Cmd get option response                  #
+   #                                                                       #
+   #########################################################################
+-}
+
+
+parseCmdEchoResponse :: ParsecT String u Identity CmdResponse
+parseCmdEchoResponse = liftM CmdEchoResponse parseEchoResponse
+
+
+-- parse Echo Response
+parseEchoResponse :: ParsecT String u Identity EchoResponse
+parseEchoResponse = str
 
 {-
    #########################################################################

--- a/Smtlib/Syntax/ShowSL.hs
+++ b/Smtlib/Syntax/ShowSL.hs
@@ -47,21 +47,31 @@ instance ShowSL Command where
     " " ++ show val ++ ")"
   showSL (DefineSort str strs sort) = "(define-sort " ++ str ++
     " (" ++ unwords strs ++ ") " ++ showSL sort ++ ") "
+  showSL (DeclareConst str sort) = "(declare-fun  " ++ str ++
+    " " ++ showSL sort ++ ") "
   showSL (DeclareFun  str sorts sort) = "(declare-fun  " ++ str ++
     " ("  ++ joinA sorts ++ ") " ++ showSL sort ++ ") "
   showSL (DefineFun str srvs sort term) = "( define-fun "   ++ str ++
     " (" ++ joinA srvs ++ ") " ++ showSL sort ++ " " ++ showSL term ++ ")"
+  showSL (DefineFunRec str srvs sort term) = "(define-fun-rec "   ++ str ++
+    " (" ++ joinA srvs ++ ") " ++ showSL sort ++ " " ++ showSL term ++ ")"
+  showSL (DefineFunsRec fundecs terms) = "(define-fun-recs " ++
+    " (" ++ joinA fundecs ++ ") (" ++ joinA terms ++ "))"
   showSL (Push n) = "(push " ++ show n ++ ")"
   showSL (Pop n) = "(pop " ++show n ++ ")"
   showSL (Assert term) = "(assert " ++ showSL term ++ ")"
   showSL CheckSat = "(check-sat)"
   showSL GetAssertions = "(get-assertions)"
+  showSL GetModel = "(get-model)"
   showSL GetProof = "(get-proof)"
   showSL GetUnsatCore = "(get-unsat-core)"
   showSL (GetValue terms) = "( (" ++ joinA terms ++ ") )"
   showSL GetAssignment =  "(get-assignment)"
   showSL (GetOption opt) = "(get-option " ++ opt ++ ")"
   showSL (GetInfo info) = "(get-info " ++ showSL info ++ ")"
+  showSL Reset = "(reset)"
+  showSL ResetAssertions = "(reset-assertions)"
+  showSL (Echo str) = "(echo " ++ str ++ ")"
   showSL Exit = "(exit)"
 
 
@@ -77,10 +87,13 @@ instance ShowSL Option where
   showSL (ProduceUnsatCores b) = ":produce-unsat-cores " ++  showSL b
   showSL (ProduceModels b) = ":produce-models " ++ showSL b
   showSL (ProduceAssignments b) = ":produce-assignments " ++ showSL b
+  showSL (ProduceAssertions b) = ":produce-assertions " ++ showSL b
+  showSL (GlobalDeclarations b) = ":global-declarations " ++ showSL b
   showSL (RegularOutputChannel s) = ":regular-output-channel " ++ s
   showSL (DiagnosticOutputChannel s) = ":diagnostic-output-channel " ++ s
   showSL (RandomSeed n) = ":random-seed " ++ show n
-  showSL (Verbosity n) = ":verbosity'" ++ show n
+  showSL (Verbosity n) = ":verbosity " ++ show n
+  showSL (ReproducibleResourceLimit n) = ":reproducible-resource-limit " ++ show n
   showSL (OptionAttr attr) = show attr
 
 instance ShowSL InfoFlags where
@@ -118,6 +131,10 @@ instance ShowSL QualIdentifier where
   showSL (QIdentifier iden) = showSL iden
   showSL (QIdentifierAs iden sort) =
     "(as " ++ showSL iden ++ " " ++ showSL sort ++ ")"
+
+instance ShowSL FunDec where
+  showSL (FunDec str srvs sort) =
+    "(" ++ str ++ " (" ++ joinA srvs ++ ") " ++ showSL sort ++ ")"
 
 instance ShowSL AttrValue where
   showSL (AttrValueConstant spc) = showSL spc
@@ -168,7 +185,9 @@ instance ShowSL CmdResponse where
   showSL (CmdGetProofResponse x) = showSL x
   showSL (CmdGetUnsatCoreResponse x) = "(" ++ unwords x ++ ")"
   showSL (CmdGetValueResponse x) = "(" ++ joinA x ++ ")"
+  showSL (CmdGetModelResponse cmds) = "(" ++ joinA cmds ++ ")"
   showSL (CmdGetOptionResponse x) = showSL x
+  showSL (CmdEchoResponse x) = x
 
 
 instance ShowSL GenResponse where

--- a/Smtlib/Syntax/Syntax.hs
+++ b/Smtlib/Syntax/Syntax.hs
@@ -28,19 +28,26 @@ data Command = SetLogic String
              | SetInfo Attribute
              | DeclareSort String Int
              | DefineSort String [String] Sort
+             | DeclareConst String Sort
              | DeclareFun String [Sort] Sort
              | DefineFun String [SortedVar] Sort Term
+             | DefineFunRec String [SortedVar] Sort Term
+             | DefineFunsRec [FunDec] [Term]
              | Push Int
              | Pop Int
+             | Reset
+             | ResetAssertions
              | Assert Term
              | CheckSat
              | GetAssertions
+             | GetModel
              | GetProof
              | GetUnsatCore
              | GetValue [Term]
              | GetAssignment
              | GetOption String
              | GetInfo InfoFlags
+             | Echo String
              | Exit
              deriving (Show,Eq)
 
@@ -51,10 +58,13 @@ data Option = PrintSuccess Bool
             | ProduceUnsatCores Bool
             | ProduceModels Bool
             | ProduceAssignments Bool
+            | ProduceAssertions Bool
+            | GlobalDeclarations Bool
             | RegularOutputChannel String
             | DiagnosticOutputChannel String
             | RandomSeed Int
             | Verbosity Int
+            | ReproducibleResourceLimit Int -- fixme
             | OptionAttr Attribute
              deriving (Show,Eq)
 
@@ -95,6 +105,7 @@ data QualIdentifier = QIdentifier Identifier
                     deriving (Show,Eq)
 
 
+data FunDec = FunDec String [SortedVar] Sort deriving (Show,Eq)
 
 
 
@@ -168,7 +179,9 @@ data CmdResponse = CmdGenResponse GenResponse
                  | CmdGetProofResponse GetProofResponse
                  | CmdGetUnsatCoreResponse GetUnsatCoreResponse
                  | CmdGetValueResponse GetValueResponse
+                 | CmdGetModelResponse GetModelResponse
                  | CmdGetOptionResponse GetOptionResponse
+                 | CmdEchoResponse EchoResponse
                  deriving (Show, Eq)
 
 
@@ -227,6 +240,8 @@ data ValuationPair = ValuationPair Term Term deriving (Show, Eq)
 
 type GetValueResponse = [ValuationPair]
 
+type GetModelResponse = [Command]
+
 
 -- get Assignment Response
 
@@ -238,3 +253,7 @@ type GetAssignmentResponse = [TValuationPair]
 -- Get Option Response
 
 type GetOptionResponse = AttrValue
+
+-- Echo Response
+
+type EchoResponse = String


### PR DESCRIPTION
This patch add supports for commands and options that were added to SMT-LIB 2.5.
- commands: declare-const, define-fun-rec, define-funs-rec, reset, reset-assertions, get-model, echo
- options: :produce-assertions, :global-declarations, :reproducible-resource-limit
