### PR TITLE
allow omitting arguments of push/pop commands

### DIFF
--- a/Smtlib/Parsers/CommandsParsers.hs
+++ b/Smtlib/Parsers/CommandsParsers.hs
@@ -183,10 +183,12 @@ parsePush = do
   _ <- emptySpace
   _ <- string "push"
   _ <- emptySpace
-  nume <- numeral
-  _ <- emptySpace
+  nume <- option 1 $ do
+    nume <- numeral
+    _ <- emptySpace
+    return (read nume :: Int)
   _ <- aspC
-  return $ Push (read nume :: Int)
+  return $ Push nume
 
 
 parsePop :: ParsecT String u Identity Command
@@ -195,10 +197,12 @@ parsePop = do
   _ <- emptySpace
   _ <- string "pop"
   _ <- emptySpace
-  nume <- numeral
-  _ <- emptySpace
+  nume <- option 1 $ do
+    nume <- numeral
+    _ <- emptySpace
+    return (read nume :: Int)
   _ <- aspC
-  return $ Pop (read nume :: Int)
+  return $ Pop nume
 
 
 


### PR DESCRIPTION
This changes the parser to allow omitting arguments of push/pop commands
Note that it is not specified in SMT-LIB2, but many solvers implement the omission.
