### PR TITLE
fix typo: 'error-behaviour' -> 'error-behavior'

### DIFF
--- a/Smtlib/Parsers/CommandsParsers.hs
+++ b/Smtlib/Parsers/CommandsParsers.hs
@@ -448,7 +448,7 @@ parseInfoFlags = parseErrorBehaviour
 
 
 parseErrorBehaviour :: ParsecT String u Identity InfoFlags
-parseErrorBehaviour = string ":error-behaviour" *> return ErrorBehavior
+parseErrorBehaviour = string ":error-behavior" *> return ErrorBehavior
 
 
 parseName :: ParsecT String u Identity InfoFlags

--- a/Smtlib/Syntax/ShowSL.hs
+++ b/Smtlib/Syntax/ShowSL.hs
@@ -190,7 +190,7 @@ instance ShowSL CheckSatResponse where
   showSL Unknown = "unknown"
 
 instance ShowSL InfoResponse where
-  showSL (ResponseErrorBehavior x) = ":error-behaviour " ++ showSL x
+  showSL (ResponseErrorBehavior x) = ":error-behavior " ++ showSL x
   showSL (ResponseName s) = ":name " ++ s
   showSL (ResponseAuthors s) = ":authors " ++ s
   showSL (ResponseVersion s) = ":version" ++ s


### PR DESCRIPTION
Fixing typo: 'error-behaviour' -> 'error-behavior'. 

The SMT-LIB2 standard uses American spelling.
