### PR TITLE
Identifiers indexed not just with numerals but also with symbols

### DIFF
--- a/Smtlib/Parsers/CommonParsers.hs
+++ b/Smtlib/Parsers/CommonParsers.hs
@@ -379,9 +379,9 @@ parseNSymbol = do
        _ <- emptySpace
        symb <- symbol
        _ <- emptySpace
-       nume <- many1  (numeral <* Pc.try spaces)
+       indexes <- many1 ((liftM (IndexNumeral . read) numeral <|> liftM IndexSymbol symbol) <* Pc.try spaces)
        _ <- aspC
-       return $ I_Symbol symb (fmap (read) nume)
+       return $ I_Symbol symb indexes
 
 {-
    #########################################################################

--- a/Smtlib/Syntax/ShowSL.hs
+++ b/Smtlib/Syntax/ShowSL.hs
@@ -128,9 +128,13 @@ instance ShowSL Attribute where
   showSL (Attribute str) = str
   showSL (AttributeVal str attrVal) = str ++ " " ++ showSL attrVal
 
+instance ShowSL Index where
+  showSL (IndexNumeral i) = show i
+  showSL (IndexSymbol str) = str
+
 instance ShowSL Identifier where
   showSL (ISymbol str) = str
-  showSL (I_Symbol str ns) = "( _ " ++ str ++ " " ++ joinNs ns  ++ ")"
+  showSL (I_Symbol str is) = "(_ " ++ str ++ " " ++ joinA is  ++ ")"
 
 instance ShowSL Sort where
   showSL (SortId iden) = showSL iden

--- a/Smtlib/Syntax/Syntax.hs
+++ b/Smtlib/Syntax/Syntax.hs
@@ -115,8 +115,12 @@ data Attribute = Attribute String
 
 -- Identifiers
 
+data Index = IndexNumeral Int
+           | IndexSymbol String
+           deriving (Show,Eq)
+
 data Identifier = ISymbol String
-                | I_Symbol String [Int] deriving (Show,Eq)
+                | I_Symbol String [Index] deriving (Show,Eq)
 
 -- Sorts
 


### PR DESCRIPTION
SMT-LIB 2.5 allowed identifiers to be indexed not just with numerals but also with symbols.
