### PR TITLE
fix typo: 'imcomplete' -> 'incomplete'

### DIFF
--- a/Smtlib/Syntax/ShowSL.hs
+++ b/Smtlib/Syntax/ShowSL.hs
@@ -201,7 +201,7 @@ instance ShowSL ErrorBehavior where
 
 instance ShowSL ReasonUnknown where
   showSL Memout = "memout"
-  showSL Incomplete = "imcomplete"
+  showSL Incomplete = "incomplete"
 
 instance ShowSL CheckSatResponse where
   showSL Sat = "sat"


### PR DESCRIPTION
This PR fixes typo in Smtlib.Syntax.ShowSL module ('imcomplete' -> 'incomplete').
