### PR TITLE
Fixing ShowSL of SpecConstantBinary and SpecConstantHexadecimal

### DIFF
--- a/Smtlib/Syntax/ShowSL.hs
+++ b/Smtlib/Syntax/ShowSL.hs
@@ -157,8 +157,8 @@ instance ShowSL Sort where
 instance ShowSL SpecConstant where
   showSL (SpecConstantNumeral n) = show n
   showSL (SpecConstantDecimal str) = str
-  showSL (SpecConstantHexadecimal str) = str
-  showSL (SpecConstantBinary str)  = str
+  showSL (SpecConstantHexadecimal str) = "#x" ++ str
+  showSL (SpecConstantBinary str)  = "#b" ++ str
   showSL (SpecConstantString str) = str
 
 instance ShowSL Sexpr where


### PR DESCRIPTION
This PR fixes ShowSL of SpecConstantBinary and SpecConstantHexadecimal to produce strings that can be parsed by corresponding parsers.
