### PR TITLE
Parsing 'unknown' response of (check-sat) correctly

### DIFF
--- a/Smtlib/Parsers/ResponseParsers.hs
+++ b/Smtlib/Parsers/ResponseParsers.hs
@@ -171,7 +171,7 @@ parseCmdCheckSatResponse = liftM  CmdCheckSatResponse parseCheckSatResponse
 parseCheckSatResponse :: ParsecT String u Identity CheckSatResponse
 parseCheckSatResponse =
     (string "sat" >> return Sat) <|>
-    (string "unsat" >> return Unsat) <|>
+    Pc.try (string "unsat" >> return Unsat) <|>
     (string "unknown" >> return Unknown)
 
 


### PR DESCRIPTION
This PR allow parsing 'unknown' response of (check-sat) correctly.

Since 'unsat' and 'unknown' shares common prefix 'un', it is necessary to use 'try' combinator.
