### PR TITLE
Correctly parsing the output of (get-info :reason-unknown)

### DIFF
--- a/Smtlib/Parsers/ResponseParsers.hs
+++ b/Smtlib/Parsers/ResponseParsers.hs
@@ -133,7 +133,7 @@ parseResponseVersion = string ":version" *> emptySpace *>
 
 
 parseResponseReasonUnknown :: ParsecT String u Identity InfoResponse
-parseResponseReasonUnknown = string "reason" *> emptySpace *>
+parseResponseReasonUnknown = string ":reason-unknown" *> emptySpace *>
     liftM ResponseReasonUnknown parseRReasonUnknown
 
 parseRReasonUnknown :: ParsecT String u Identity ReasonUnknown


### PR DESCRIPTION
This PR fixes `parseResponseReasonUnknown` parser so that it can correctly parse responses to `(get-info :reason-unknown)` as defined in SMT-LIB2 standard.
