### PR TITLE
fix a bug of parseSexprKeyword

### DIFF
--- a/Smtlib/Parsers/CommonParsers.hs
+++ b/Smtlib/Parsers/CommonParsers.hs
@@ -401,7 +401,7 @@ parseSexprSymbol :: ParsecT String u Identity Sexpr
 parseSexprSymbol = liftM SexprSymbol symbol
 
 parseSexprKeyword :: ParsecT String u Identity Sexpr
-parseSexprKeyword = liftM SexprSymbol keyword
+parseSexprKeyword = liftM SexprKeyword keyword
 
 parseAtomSexpr :: ParsecT String u Identity Sexpr
 parseAtomSexpr = parseSexprConstant


### PR DESCRIPTION
This PR fixes parseSexprKeyword to wrap parsed values using `SexprKeyword` constructor instead of `SexprSymbol` constructor.
