### PR TITLE
OptionAttr argument should be printed using 'showSL' instead of 'show'

### DIFF
--- a/Smtlib/Syntax/ShowSL.hs
+++ b/Smtlib/Syntax/ShowSL.hs
@@ -94,7 +94,7 @@ instance ShowSL Option where
   showSL (RandomSeed n) = ":random-seed " ++ show n
   showSL (Verbosity n) = ":verbosity " ++ show n
   showSL (ReproducibleResourceLimit n) = ":reproducible-resource-limit " ++ show n
-  showSL (OptionAttr attr) = show attr
+  showSL (OptionAttr attr) = showSL attr
 
 instance ShowSL InfoFlags where
   showSL ErrorBehavior = ":error-behavior"


### PR DESCRIPTION
OptionAttr argument  should be printed using 'showSL' instead of 'show'.
This is necessary to produce strings that can be parsed by corresponding parsers.
