### PR TITLE
Supporting check-sat-assuming, get-unsat-assumptions commands and :produce-unsat-assumptions option

### DIFF
--- a/Smtlib/Parsers/CommandsParsers.hs
+++ b/Smtlib/Parsers/CommandsParsers.hs
@@ -53,10 +53,12 @@ parseCommand = Pc.try parseSetLogic
            <|> Pc.try parsePop
            <|> Pc.try parseAssert
            <|> Pc.try parseCheckSat
+           <|> Pc.try parseCheckSatAssuming
            <|> Pc.try parseGetAssertions
            <|> Pc.try parseGetModel
            <|> Pc.try parseGetProof
            <|> Pc.try parseGetUnsatCore
+           <|> Pc.try parseGetUnsatAssumptions
            <|> Pc.try parseGetValue
            <|> Pc.try parseGetAssignment
            <|> Pc.try parseGetOption
@@ -300,6 +302,20 @@ parseCheckSat = do
   _ <- aspC
   return CheckSat
 
+parseCheckSatAssuming :: ParsecT String u Identity Command
+parseCheckSatAssuming = do
+  _ <- aspO
+  _ <- emptySpace
+  _ <- string "check-sat-assuming"
+  _ <- emptySpace
+  _ <- aspO
+  emptySpace
+  terms <- Pc.many $ parseTerm <* Pc.try emptySpace
+  _ <- aspC
+  _ <- emptySpace
+  _ <- aspC
+  return (CheckSatAssuming terms)
+
 
 parseGetAssertions :: ParsecT String u Identity Command
 parseGetAssertions = do
@@ -336,6 +352,15 @@ parseGetUnsatCore = do
   _ <- emptySpace
   _ <- aspC
   return GetUnsatCore
+
+parseGetUnsatAssumptions :: ParsecT String u Identity Command
+parseGetUnsatAssumptions = do
+  _ <- aspO
+  _ <- emptySpace
+  _ <- string "get-unsat-assumptions"
+  _ <- emptySpace
+  _ <- aspC
+  return GetUnsatAssumptions
 
 parseGetValue :: ParsecT String u Identity Command
 parseGetValue = do
@@ -440,6 +465,7 @@ parseOption = Pc.try parsePrintSuccess
           <|> Pc.try parseInteractiveMode
           <|> Pc.try parseProduceProofs
           <|> Pc.try parseProduceUnsatCores
+          <|> Pc.try parseProduceUnsatAssumptions
           <|> Pc.try parseProduceModels
           <|> Pc.try parseProduceAssignments
           <|> Pc.try parseProduceAssertions
@@ -491,6 +517,12 @@ parseProduceUnsatCores = do
   val <- parseBool
   return $ ProduceUnsatCores val
 
+parseProduceUnsatAssumptions :: ParsecT String u Identity Option
+parseProduceUnsatAssumptions = do
+  _ <- string ":produce-unsat-assumptions"
+  _ <- spaces
+  val <- parseBool
+  return $ ProduceUnsatAssumptions val
 
 parseProduceModels :: ParsecT String u Identity Option
 parseProduceModels = do

--- a/Smtlib/Syntax/ShowSL.hs
+++ b/Smtlib/Syntax/ShowSL.hs
@@ -61,10 +61,12 @@ instance ShowSL Command where
   showSL (Pop n) = "(pop " ++show n ++ ")"
   showSL (Assert term) = "(assert " ++ showSL term ++ ")"
   showSL CheckSat = "(check-sat)"
+  showSL (CheckSatAssuming terms) = "(check-sat-assuming (" ++ joinA terms ++ "))"
   showSL GetAssertions = "(get-assertions)"
   showSL GetModel = "(get-model)"
   showSL GetProof = "(get-proof)"
   showSL GetUnsatCore = "(get-unsat-core)"
+  showSL GetUnsatAssumptions = "(get-unsat-assumptions)"
   showSL (GetValue terms) = "( (" ++ joinA terms ++ ") )"
   showSL GetAssignment =  "(get-assignment)"
   showSL (GetOption opt) = "(get-option " ++ opt ++ ")"
@@ -85,6 +87,7 @@ instance ShowSL Option where
   showSL (InteractiveMode b) = ":interactive-mode " ++ showSL b
   showSL (ProduceProofs b) = ":produce-proofs " ++ showSL b
   showSL (ProduceUnsatCores b) = ":produce-unsat-cores " ++  showSL b
+  showSL (ProduceUnsatAssumptions b) = ":produce-unsat-assumptions " ++  showSL b
   showSL (ProduceModels b) = ":produce-models " ++ showSL b
   showSL (ProduceAssignments b) = ":produce-assignments " ++ showSL b
   showSL (ProduceAssertions b) = ":produce-assertions " ++ showSL b
@@ -184,6 +187,7 @@ instance ShowSL CmdResponse where
   showSL (CmdGetAssignmentResponse x) = "(" ++ joinA x ++ ")"
   showSL (CmdGetProofResponse x) = showSL x
   showSL (CmdGetUnsatCoreResponse x) = "(" ++ unwords x ++ ")"
+  showSL (CmdGetUnsatAssumptionsResponse terms) = "(" ++  joinA terms ++ ")"
   showSL (CmdGetValueResponse x) = "(" ++ joinA x ++ ")"
   showSL (CmdGetModelResponse cmds) = "(" ++ joinA cmds ++ ")"
   showSL (CmdGetOptionResponse x) = showSL x

--- a/Smtlib/Syntax/Syntax.hs
+++ b/Smtlib/Syntax/Syntax.hs
@@ -39,10 +39,12 @@ data Command = SetLogic String
              | ResetAssertions
              | Assert Term
              | CheckSat
+             | CheckSatAssuming [Term]
              | GetAssertions
              | GetModel
              | GetProof
              | GetUnsatCore
+             | GetUnsatAssumptions
              | GetValue [Term]
              | GetAssignment
              | GetOption String
@@ -56,6 +58,7 @@ data Option = PrintSuccess Bool
             | InteractiveMode Bool
             | ProduceProofs Bool
             | ProduceUnsatCores Bool
+            | ProduceUnsatAssumptions Bool
             | ProduceModels Bool
             | ProduceAssignments Bool
             | ProduceAssertions Bool
@@ -178,6 +181,7 @@ data CmdResponse = CmdGenResponse GenResponse
                  | CmdGetAssignmentResponse GetAssignmentResponse
                  | CmdGetProofResponse GetProofResponse
                  | CmdGetUnsatCoreResponse GetUnsatCoreResponse
+                 | CmdGetUnsatAssumptionsResponse GetUnsatAssumptionsResponse
                  | CmdGetValueResponse GetValueResponse
                  | CmdGetModelResponse GetModelResponse
                  | CmdGetOptionResponse GetOptionResponse
@@ -232,6 +236,9 @@ type GetProofResponse = Sexpr
 
 type GetUnsatCoreResponse = [String]
 
+-- Get Unsat Assumptions Response
+
+type GetUnsatAssumptionsResponse = [Term]
 
 -- Get Valuation Pair
 


### PR DESCRIPTION
This PR adds support of check-sat-assuming, get-unsat-assumptions commands and :produce-unsat-assumptions option that were added by SMT-LIB 2.5.

Sorry, I should have included the change in the PR #14.
