### PR TITLE
Supporting (get-info :assertion-stack-levels) command added in SMT-LIB 2.5

### DIFF
--- a/Smtlib/Parsers/CommandsParsers.hs
+++ b/Smtlib/Parsers/CommandsParsers.hs
@@ -584,6 +584,7 @@ parseInfoFlags = Pc.try parseErrorBehaviour
              <|> Pc.try parseStatus
              <|> Pc.try parseReasonUnknown
              <|> Pc.try parseAllStatistics
+             <|> Pc.try parseAssertionStackLevels
              <|> parseInfoKeyword
 
 
@@ -608,6 +609,9 @@ parseReasonUnknown = string ":reason-unknown" *> return  ReasonUnknown
 
 parseAllStatistics :: ParsecT String u Identity InfoFlags
 parseAllStatistics = string ":all-statistics" *> return AllStatistics
+
+parseAssertionStackLevels :: ParsecT String u Identity InfoFlags
+parseAssertionStackLevels = string ":assertion-stack-levels" *> return AssertionStackLevels
 
 parseInfoKeyword :: ParsecT String u Identity InfoFlags
 parseInfoKeyword = liftM InfoFlags keyword

--- a/Smtlib/Parsers/ResponseParsers.hs
+++ b/Smtlib/Parsers/ResponseParsers.hs
@@ -103,6 +103,7 @@ parseInfoResponse =
     Pc.try parseResponseAuthors <|>
     Pc.try parseResponseVersion <|>
     Pc.try parseResponseReasonUnknown <|>
+    Pc.try parseResponseAssertionStackLevels <|>
     parseResponseAttribute
 
 
@@ -141,6 +142,10 @@ parseRReasonUnknown =
     (string "memout" >> return Memout) <|>
     (string "incomplete" >> return Incomplete)
 
+parseResponseAssertionStackLevels :: ParsecT String u Identity InfoResponse
+parseResponseAssertionStackLevels =
+  string ":assertion-stack-levels" *> emptySpace *>
+    liftM ResponseAssertionStackLevels (liftM read numeral)
 
 
 parseResponseAttribute :: ParsecT String u Identity InfoResponse

--- a/Smtlib/Syntax/ShowSL.hs
+++ b/Smtlib/Syntax/ShowSL.hs
@@ -104,6 +104,7 @@ instance ShowSL InfoFlags where
   showSL Status = ":status"
   showSL ReasonUnknown = ":reason-unknown"
   showSL AllStatistics = ":all-statistics"
+  showSL AssertionStackLevels = ":assertion-stack-levels"
   showSL (InfoFlags s) = s
 
 
@@ -214,6 +215,7 @@ instance ShowSL InfoResponse where
   showSL (ResponseAuthors s) = ":authors " ++ s
   showSL (ResponseVersion s) = ":version" ++ s
   showSL (ResponseReasonUnknown x) = ":reason-unknown " ++ showSL x
+  showSL (ResponseAssertionStackLevels n) = ":assertion-stack-levels " ++ show n
   showSL (ResponseAttribute x)  = showSL x
 
 instance ShowSL ValuationPair where

--- a/Smtlib/Syntax/Syntax.hs
+++ b/Smtlib/Syntax/Syntax.hs
@@ -76,6 +76,7 @@ data InfoFlags = ErrorBehavior
                | Status
                | ReasonUnknown
                | AllStatistics
+               | AssertionStackLevels
                | InfoFlags String
                 deriving (Show,Eq)
 
@@ -215,6 +216,7 @@ data InfoResponse  = ResponseErrorBehavior ErrorBehavior
                    | ResponseAuthors String
                    | ResponseVersion String
                    | ResponseReasonUnknown ReasonUnknown
+                   | ResponseAssertionStackLevels Int
                    | ResponseAttribute Attribute
                    deriving (Show, Eq)
 


### PR DESCRIPTION
This PR adds support `(get-info :assertion-stack-levels)` command which was added in SMT-LIB 2.5.

Sorry, I should have included this change in PR #14.
