### PR TITLE
SMT-LIB 2.5 string literal support

### DIFF
--- a/Smtlib/Parsers/CommonParsers.hs
+++ b/Smtlib/Parsers/CommonParsers.hs
@@ -72,10 +72,7 @@ str :: ParsecT String u Identity String
 str = string "\"" <++> liftM concat (Pc.many (liftM (\c -> [c]) strChar <|> Pc.try (string "\"\""))) <++> string "\""
 
 strChar :: ParsecT String u Identity Char
-strChar = alphaNum
-      <|> char ' '
-      <|> char ':'
-      <|> char ','
+strChar = (oneOf $ ['\t','\n','\r'] ++ [c | c <- [toEnum 32 .. toEnum 126], c /= '"']) <|> satisfy (toEnum 128 <=)
 
 
 --parse a Symbol

--- a/Smtlib/Parsers/CommonParsers.hs
+++ b/Smtlib/Parsers/CommonParsers.hs
@@ -69,7 +69,7 @@ bin = char '0' <|> char '1'
 --parse a String
 -- Dosent parse strings with escape characters
 str :: ParsecT String u Identity String
-str = string "\"" <++> Pc.many strChar <++> string "\""
+str = string "\"" <++> liftM concat (Pc.many (liftM (\c -> [c]) strChar <|> Pc.try (string "\"\""))) <++> string "\""
 
 strChar :: ParsecT String u Identity Char
 strChar = alphaNum


### PR DESCRIPTION
This PR changes the string literal parser to conform to SMT-LIB 2.5 specification.
