### PR TITLE
(asX b) should not be parsed as (as X b)

### DIFF
--- a/Smtlib/Parsers/CommandsParsers.hs
+++ b/Smtlib/Parsers/CommandsParsers.hs
@@ -32,7 +32,7 @@ import           Text.ParserCombinators.Parsec as Pc
 
 
 parseSource :: ParsecT String u Identity Source
-parseSource = Pc.many $ parseCommand <* Pc.try emptySpace
+parseSource = emptySpace *> (Pc.many $ parseCommand <* Pc.try emptySpace)
 
 
 {-

--- a/Smtlib/Parsers/CommonParsers.hs
+++ b/Smtlib/Parsers/CommonParsers.hs
@@ -115,8 +115,15 @@ false = string "false"
 
 
 emptySpace :: ParsecT String u Identity String
-emptySpace = Pc.try $ Pc.many $
-    char ' ' <|> char '\n' <|> char '\t' <|> char '\r'
+emptySpace = liftM concat $ Pc.try $ Pc.many $
+    liftM (\c -> [c]) (char ' ' <|> char '\n' <|> char '\t' <|> char '\r') <|> comment
+
+comment :: ParsecT String u Identity String
+comment = char ';' <:> scan
+  where
+    scan  = do{ c <- char '\n' <|> char '\r'; return [c] }
+          <|>
+            do{ c <- anyChar; cs <- scan; return (c:cs) }
 
 reservedWords :: ParsecT String u Identity String
 reservedWords =  string "let"

--- a/Smtlib/Parsers/CommonParsers.hs
+++ b/Smtlib/Parsers/CommonParsers.hs
@@ -115,8 +115,13 @@ false = string "false"
 
 
 emptySpace :: ParsecT String u Identity String
-emptySpace = liftM concat $ Pc.try $ Pc.many $
-    liftM (\c -> [c]) (char ' ' <|> char '\n' <|> char '\t' <|> char '\r') <|> comment
+emptySpace = liftM concat $ Pc.try $ Pc.many emptySpaceSingle
+
+emptySpace1 :: ParsecT String u Identity String
+emptySpace1 = liftM concat $ Pc.try $ Pc.many1 emptySpaceSingle
+
+emptySpaceSingle :: ParsecT String u Identity String
+emptySpaceSingle = liftM (\c -> [c]) (char ' ' <|> char '\n' <|> char '\t' <|> char '\r') <|> comment
 
 comment :: ParsecT String u Identity String
 comment = char ';' <:> scan
@@ -383,7 +388,7 @@ parseNSymbol = do
        _ <- aspO
        _ <- emptySpace
        _ <- aspUS
-       _ <- emptySpace
+       _ <- emptySpace1
        symb <- symbol
        _ <- emptySpace
        nume <- many1  (numeral <* Pc.try spaces)

--- a/Smtlib/Parsers/CommonParsers.hs
+++ b/Smtlib/Parsers/CommonParsers.hs
@@ -267,7 +267,7 @@ parseQIAs = do
   _ <- aspO
   _ <- emptySpace
   _ <- string "as"
-  _ <- emptySpace
+  _ <- emptySpace1
   ident <- parseIdentifier
   _ <- emptySpace
   sort <- parseSort


### PR DESCRIPTION
It fixes the parser not to parse `(asX b)` as `(as X b)`.

This PR is intended to be merged after PR #9 and #30 .
