### PR TITLE
Quoting symbols when necessary

### DIFF
--- a/SmtLib.cabal
+++ b/SmtLib.cabal
@@ -60,6 +60,7 @@ library
   build-depends:       base >= 4.6 && < 4.9
                        , parsec ==3.1.*
                        , transformers >=0.3 && <0.5
+                       , containers
 
   default-language: Haskell2010
   -- Directories containing source files.

--- a/Smtlib/Parsers/CommandsParsers.hs
+++ b/Smtlib/Parsers/CommandsParsers.hs
@@ -53,10 +53,12 @@ parseCommand = Pc.try parseSetLogic
            <|> Pc.try parsePop
            <|> Pc.try parseAssert
            <|> Pc.try parseCheckSat
+           <|> Pc.try parseCheckSatAssuming
            <|> Pc.try parseGetAssertions
            <|> Pc.try parseGetModel
            <|> Pc.try parseGetProof
            <|> Pc.try parseGetUnsatCore
+           <|> Pc.try parseGetUnsatAssumptions
            <|> Pc.try parseGetValue
            <|> Pc.try parseGetAssignment
            <|> Pc.try parseGetOption
@@ -300,6 +302,20 @@ parseCheckSat = do
   _ <- aspC
   return CheckSat
 
+parseCheckSatAssuming :: ParsecT String u Identity Command
+parseCheckSatAssuming = do
+  _ <- aspO
+  _ <- emptySpace
+  _ <- string "check-sat-assuming"
+  _ <- emptySpace
+  _ <- aspO
+  emptySpace
+  terms <- Pc.many $ parseTerm <* Pc.try emptySpace
+  _ <- aspC
+  _ <- emptySpace
+  _ <- aspC
+  return (CheckSatAssuming terms)
+
 
 parseGetAssertions :: ParsecT String u Identity Command
 parseGetAssertions = do
@@ -336,6 +352,15 @@ parseGetUnsatCore = do
   _ <- emptySpace
   _ <- aspC
   return GetUnsatCore
+
+parseGetUnsatAssumptions :: ParsecT String u Identity Command
+parseGetUnsatAssumptions = do
+  _ <- aspO
+  _ <- emptySpace
+  _ <- string "get-unsat-assumptions"
+  _ <- emptySpace
+  _ <- aspC
+  return GetUnsatAssumptions
 
 parseGetValue :: ParsecT String u Identity Command
 parseGetValue = do
@@ -440,6 +465,7 @@ parseOption = Pc.try parsePrintSuccess
           <|> Pc.try parseInteractiveMode
           <|> Pc.try parseProduceProofs
           <|> Pc.try parseProduceUnsatCores
+          <|> Pc.try parseProduceUnsatAssumptions
           <|> Pc.try parseProduceModels
           <|> Pc.try parseProduceAssignments
           <|> Pc.try parseProduceAssertions
@@ -491,6 +517,12 @@ parseProduceUnsatCores = do
   val <- parseBool
   return $ ProduceUnsatCores val
 
+parseProduceUnsatAssumptions :: ParsecT String u Identity Option
+parseProduceUnsatAssumptions = do
+  _ <- string ":produce-unsat-assumptions"
+  _ <- spaces
+  val <- parseBool
+  return $ ProduceUnsatAssumptions val
 
 parseProduceModels :: ParsecT String u Identity Option
 parseProduceModels = do

--- a/Smtlib/Parsers/CommonParsers.hs
+++ b/Smtlib/Parsers/CommonParsers.hs
@@ -379,9 +379,9 @@ parseNSymbol = do
        _ <- emptySpace
        symb <- symbol
        _ <- emptySpace
-       nume <- many1  (numeral <* Pc.try spaces)
+       indexes <- many1 ((liftM (IndexNumeral . read) numeral <|> liftM IndexSymbol symbol) <* Pc.try spaces)
        _ <- aspC
-       return $ I_Symbol symb (fmap (read) nume)
+       return $ I_Symbol symb indexes
 
 {-
    #########################################################################

--- a/Smtlib/Syntax/ShowSL.hs
+++ b/Smtlib/Syntax/ShowSL.hs
@@ -55,7 +55,7 @@ instance ShowSL Command where
     " (" ++ joinA srvs ++ ") " ++ showSL sort ++ " " ++ showSL term ++ ")"
   showSL (DefineFunRec str srvs sort term) = "(define-fun-rec "   ++ str ++
     " (" ++ joinA srvs ++ ") " ++ showSL sort ++ " " ++ showSL term ++ ")"
-  showSL (DefineFunsRec fundecs terms) = "(define-fun-recs " ++
+  showSL (DefineFunsRec fundecs terms) = "(define-funs-rec " ++
     " (" ++ joinA fundecs ++ ") (" ++ joinA terms ++ "))"
   showSL (Push n) = "(push " ++ show n ++ ")"
   showSL (Pop n) = "(pop " ++show n ++ ")"

--- a/Smtlib/Syntax/ShowSL.hs
+++ b/Smtlib/Syntax/ShowSL.hs
@@ -202,4 +202,4 @@ instance ShowSL ValuationPair where
     "(" ++ showSL term1 ++ " " ++ showSL term2 ++ ")"
 
 instance ShowSL TValuationPair where
-  showSL (TValuationPair str b) = "(" ++ str ++ " " ++ show b ++ ")"
+  showSL (TValuationPair str b) = "(" ++ str ++ " " ++ showSL b ++ ")"

--- a/Smtlib/Syntax/ShowSL.hs
+++ b/Smtlib/Syntax/ShowSL.hs
@@ -11,6 +11,8 @@ Functions to print the syntax as a SMTLib.
 -}
 module Smtlib.Syntax.ShowSL where
 
+import           Data.Char
+import qualified Data.Set as Set
 import           Data.List
 import           Smtlib.Syntax.Syntax
 
@@ -23,6 +25,18 @@ joinA = unwords.fmap showSL
 
 joinNs :: [Int] -> String
 joinNs = unwords.fmap show
+
+showSymbol :: String -> String
+showSymbol s
+  | c:_ <- s, isDigit c = quoted
+  | all p s && s `Set.notMember` reserved = s
+  | otherwise = quoted
+  where
+    quoted = "|" ++ s ++ "|"
+    p c = (isAscii c && isAlpha c) || isDigit c || c `elem` "~!@$%^&*_-+=<>.?/"
+    reserved = Set.fromList $
+      ["BINARY", "DECIMAL", "HEXADECIMAL", "NUMERAL", "STRING", "_", "!", "as", "let", "exists", "forall", "par"] ++
+      ["set-logic", "set-option", "set-info", "declare-sort", "define-sort", "declare-const", "declare-fun", "declare-fun-rec", "declare-funs-rec", "push", "pop", "reset", "reset-assertions", "assert", "check-sat", "check-sat-assuming", "get-assertions", "get-model", "get-proof", "get-unsat-core", "get-unsat-assumptions", "get-value", "get-assignment", "get-option", "get-info", "echo", "exit"]
 
 
 class ShowSL a where
@@ -40,20 +54,20 @@ class ShowSL a where
 
 
 instance ShowSL Command where
-  showSL (SetLogic s) = "(set-logic " ++ s ++ ")"
+  showSL (SetLogic s) = "(set-logic " ++ showSymbol s ++ ")"
   showSL (SetOption opt) = "(set-option " ++ showSL opt ++ ")"
   showSL (SetInfo info) = "(set-info " ++ showSL info ++ ")"
-  showSL (DeclareSort str val) =  "(declare-sort " ++ str ++
+  showSL (DeclareSort str val) =  "(declare-sort " ++ showSymbol str ++
     " " ++ show val ++ ")"
-  showSL (DefineSort str strs sort) = "(define-sort " ++ str ++
-    " (" ++ unwords strs ++ ") " ++ showSL sort ++ ") "
-  showSL (DeclareConst str sort) = "(declare-fun  " ++ str ++
+  showSL (DefineSort str strs sort) = "(define-sort " ++ showSymbol str ++
+    " (" ++ unwords (map showSymbol strs) ++ ") " ++ showSL sort ++ ") "
+  showSL (DeclareConst str sort) = "(declare-const  " ++ showSymbol str ++
     " " ++ showSL sort ++ ") "
-  showSL (DeclareFun  str sorts sort) = "(declare-fun  " ++ str ++
+  showSL (DeclareFun  str sorts sort) = "(declare-fun  " ++ showSymbol str ++
     " ("  ++ joinA sorts ++ ") " ++ showSL sort ++ ") "
-  showSL (DefineFun str srvs sort term) = "( define-fun "   ++ str ++
+  showSL (DefineFun str srvs sort term) = "(define-fun "   ++ showSymbol str ++
     " (" ++ joinA srvs ++ ") " ++ showSL sort ++ " " ++ showSL term ++ ")"
-  showSL (DefineFunRec str srvs sort term) = "(define-fun-rec "   ++ str ++
+  showSL (DefineFunRec str srvs sort term) = "(define-fun-rec "   ++ showSymbol str ++
     " (" ++ joinA srvs ++ ") " ++ showSL sort ++ " " ++ showSL term ++ ")"
   showSL (DefineFunsRec fundecs terms) = "(define-funs-rec " ++
     " (" ++ joinA fundecs ++ ") (" ++ joinA terms ++ "))"
@@ -125,10 +139,10 @@ instance ShowSL Term where
     "(! " ++ showSL term ++ " " ++ joinA atts ++ ")"
 
 instance ShowSL VarBinding where
-  showSL (VB str term) = "("++ str ++ " " ++ showSL term ++ ")"
+  showSL (VB str term) = "("++ showSymbol str ++ " " ++ showSL term ++ ")"
 
 instance ShowSL SortedVar where
-  showSL (SV str sort)  = "(" ++ str ++ " " ++ showSL sort ++ ")"
+  showSL (SV str sort)  = "(" ++ showSymbol str ++ " " ++ showSL sort ++ ")"
 
 instance ShowSL QualIdentifier where
   showSL (QIdentifier iden) = showSL iden
@@ -137,11 +151,11 @@ instance ShowSL QualIdentifier where
 
 instance ShowSL FunDec where
   showSL (FunDec str srvs sort) =
-    "(" ++ str ++ " (" ++ joinA srvs ++ ") " ++ showSL sort ++ ")"
+    "(" ++ showSymbol str ++ " (" ++ joinA srvs ++ ") " ++ showSL sort ++ ")"
 
 instance ShowSL AttrValue where
   showSL (AttrValueConstant spc) = showSL spc
-  showSL (AttrValueSymbol str) = str
+  showSL (AttrValueSymbol str) = showSymbol str
   showSL (AttrValueSexpr sexprs) = "(" ++ joinA sexprs  ++ ")"
 
 instance ShowSL Attribute where
@@ -150,11 +164,11 @@ instance ShowSL Attribute where
 
 instance ShowSL Index where
   showSL (IndexNumeral i) = show i
-  showSL (IndexSymbol str) = str
+  showSL (IndexSymbol str) = showSymbol str
 
 instance ShowSL Identifier where
-  showSL (ISymbol str) = str
-  showSL (I_Symbol str is) = "(_ " ++ str ++ " " ++ joinA is  ++ ")"
+  showSL (ISymbol str) = showSymbol str
+  showSL (I_Symbol str is) = "(_ " ++ showSymbol str ++ " " ++ joinA is  ++ ")"
 
 instance ShowSL Sort where
   showSL (SortId iden) = showSL iden
@@ -170,7 +184,7 @@ instance ShowSL SpecConstant where
 
 instance ShowSL Sexpr where
   showSL (SexprSpecConstant sc) = showSL sc
-  showSL (SexprSymbol str) = str
+  showSL (SexprSymbol str) = showSymbol str
   showSL (SexprKeyword str) = str
   showSL (SexprSxp srps) = "(" ++ joinA srps ++ ")"
 
@@ -190,7 +204,7 @@ instance ShowSL CmdResponse where
   showSL (CmdGetAssertionsResponse x) = "(" ++ joinA x ++ ")"
   showSL (CmdGetAssignmentResponse x) = "(" ++ joinA x ++ ")"
   showSL (CmdGetProofResponse x) = showSL x
-  showSL (CmdGetUnsatCoreResponse x) = "(" ++ unwords x ++ ")"
+  showSL (CmdGetUnsatCoreResponse x) = "(" ++ unwords (map showSymbol x) ++ ")"
   showSL (CmdGetUnsatAssumptionsResponse terms) = "(" ++  joinA terms ++ ")"
   showSL (CmdGetValueResponse x) = "(" ++ joinA x ++ ")"
   showSL (CmdGetModelResponse cmds) = "(" ++ joinA cmds ++ ")"
@@ -229,4 +243,4 @@ instance ShowSL ValuationPair where
     "(" ++ showSL term1 ++ " " ++ showSL term2 ++ ")"
 
 instance ShowSL TValuationPair where
-  showSL (TValuationPair str b) = "(" ++ str ++ " " ++ showSL b ++ ")"
+  showSL (TValuationPair str b) = "(" ++ showSymbol str ++ " " ++ showSL b ++ ")"

--- a/Smtlib/Syntax/ShowSL.hs
+++ b/Smtlib/Syntax/ShowSL.hs
@@ -128,9 +128,13 @@ instance ShowSL Attribute where
   showSL (Attribute str) = str
   showSL (AttributeVal str attrVal) = str ++ " " ++ showSL attrVal
 
+instance ShowSL Index where
+  showSL (IndexNumeral i) = show i
+  showSL (IndexSymbol str) = str
+
 instance ShowSL Identifier where
   showSL (ISymbol str) = str
-  showSL (I_Symbol str ns) = "( _ " ++ str ++ " " ++ joinNs ns  ++ ")"
+  showSL (I_Symbol str is) = "(_ " ++ str ++ " " ++ joinA is  ++ ")"
 
 instance ShowSL Sort where
   showSL (SortId iden) = showSL iden

--- a/Smtlib/Syntax/ShowSL.hs
+++ b/Smtlib/Syntax/ShowSL.hs
@@ -61,10 +61,12 @@ instance ShowSL Command where
   showSL (Pop n) = "(pop " ++show n ++ ")"
   showSL (Assert term) = "(assert " ++ showSL term ++ ")"
   showSL CheckSat = "(check-sat)"
+  showSL (CheckSatAssuming terms) = "(check-sat-assuming (" ++ joinA terms ++ "))"
   showSL GetAssertions = "(get-assertions)"
   showSL GetModel = "(get-model)"
   showSL GetProof = "(get-proof)"
   showSL GetUnsatCore = "(get-unsat-core)"
+  showSL GetUnsatAssumptions = "(get-unsat-assumptions)"
   showSL (GetValue terms) = "( (" ++ joinA terms ++ ") )"
   showSL GetAssignment =  "(get-assignment)"
   showSL (GetOption opt) = "(get-option " ++ opt ++ ")"
@@ -85,6 +87,7 @@ instance ShowSL Option where
   showSL (InteractiveMode b) = ":interactive-mode " ++ showSL b
   showSL (ProduceProofs b) = ":produce-proofs " ++ showSL b
   showSL (ProduceUnsatCores b) = ":produce-unsat-cores " ++  showSL b
+  showSL (ProduceUnsatAssumptions b) = ":produce-unsat-assumptions " ++  showSL b
   showSL (ProduceModels b) = ":produce-models " ++ showSL b
   showSL (ProduceAssignments b) = ":produce-assignments " ++ showSL b
   showSL (ProduceAssertions b) = ":produce-assertions " ++ showSL b
@@ -184,6 +187,7 @@ instance ShowSL CmdResponse where
   showSL (CmdGetAssignmentResponse x) = "(" ++ joinA x ++ ")"
   showSL (CmdGetProofResponse x) = showSL x
   showSL (CmdGetUnsatCoreResponse x) = "(" ++ unwords x ++ ")"
+  showSL (CmdGetUnsatAssumptionsResponse terms) = "(" ++  joinA terms ++ ")"
   showSL (CmdGetValueResponse x) = "(" ++ joinA x ++ ")"
   showSL (CmdGetModelResponse cmds) = "(" ++ joinA cmds ++ ")"
   showSL (CmdGetOptionResponse x) = showSL x

--- a/Smtlib/Syntax/Syntax.hs
+++ b/Smtlib/Syntax/Syntax.hs
@@ -39,10 +39,12 @@ data Command = SetLogic String
              | ResetAssertions
              | Assert Term
              | CheckSat
+             | CheckSatAssuming [Term]
              | GetAssertions
              | GetModel
              | GetProof
              | GetUnsatCore
+             | GetUnsatAssumptions
              | GetValue [Term]
              | GetAssignment
              | GetOption String
@@ -56,6 +58,7 @@ data Option = PrintSuccess Bool
             | InteractiveMode Bool
             | ProduceProofs Bool
             | ProduceUnsatCores Bool
+            | ProduceUnsatAssumptions Bool
             | ProduceModels Bool
             | ProduceAssignments Bool
             | ProduceAssertions Bool
@@ -178,6 +181,7 @@ data CmdResponse = CmdGenResponse GenResponse
                  | CmdGetAssignmentResponse GetAssignmentResponse
                  | CmdGetProofResponse GetProofResponse
                  | CmdGetUnsatCoreResponse GetUnsatCoreResponse
+                 | CmdGetUnsatAssumptionsResponse GetUnsatAssumptionsResponse
                  | CmdGetValueResponse GetValueResponse
                  | CmdGetModelResponse GetModelResponse
                  | CmdGetOptionResponse GetOptionResponse
@@ -232,6 +236,9 @@ type GetProofResponse = Sexpr
 
 type GetUnsatCoreResponse = [String]
 
+-- Get Unsat Assumptions Response
+
+type GetUnsatAssumptionsResponse = [Term]
 
 -- Get Valuation Pair
 

--- a/Smtlib/Syntax/Syntax.hs
+++ b/Smtlib/Syntax/Syntax.hs
@@ -115,8 +115,12 @@ data Attribute = Attribute String
 
 -- Identifiers
 
+data Index = IndexNumeral Int
+           | IndexSymbol String
+           deriving (Show,Eq)
+
 data Identifier = ISymbol String
-                | I_Symbol String [Int] deriving (Show,Eq)
+                | I_Symbol String [Index] deriving (Show,Eq)
 
 -- Sorts
 


### PR DESCRIPTION
This changes the printer to quote symbols if the symbol cannot be simple symbols.

This PR is intended to be merged after PR #12, #18, #20, #26 .
